### PR TITLE
Fix lint errors and handle session user typing

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -82,14 +82,14 @@ export default function AdminDashboard() {
             <div className="flex items-center space-x-4">
               <div className="w-2 h-2 bg-green-500 rounded-full"></div>
               <div className="flex-1">
-                <p className="text-sm font-medium">"Mavi Rüya" teknesi temizlik işi tamamlandı</p>
+                <p className="text-sm font-medium">&quot;Mavi Rüya&quot; teknesi temizlik işi tamamlandı</p>
                 <p className="text-xs text-muted-foreground">4 saat önce</p>
               </div>
             </div>
             <div className="flex items-center space-x-4">
               <div className="w-2 h-2 bg-yellow-500 rounded-full"></div>
               <div className="flex-1">
-                <p className="text-sm font-medium">Mehmet Temizci "Deniz Yıldızı" işini başlattı</p>
+                <p className="text-sm font-medium">Mehmet Temizci &quot;Deniz Yıldızı&quot; işini başlattı</p>
                 <p className="text-xs text-muted-foreground">6 saat önce</p>
               </div>
             </div>

--- a/app/crew/jobs/[id]/page.tsx
+++ b/app/crew/jobs/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -252,16 +253,18 @@ export default function JobPage({ params }: JobPageProps) {
                           {progressRecord.media
                             .filter(m => m.kind === 'BEFORE')
                             .map((media) => (
-                              <div key={media.id} className="relative">
-                                <img
-                                  src={media.url}
-                                  alt={media.caption || "Önce"}
-                                  className="w-full h-32 object-cover rounded-md"
-                                />
-                                {media.caption && (
-                                  <p className="text-xs text-gray-600 mt-1">{media.caption}</p>
-                                )}
-                              </div>
+                                <div key={media.id} className="relative">
+                                  <Image
+                                    src={media.url}
+                                    alt={media.caption || "Önce"}
+                                    className="w-full h-32 object-cover rounded-md"
+                                    width={500}
+                                    height={500}
+                                  />
+                                  {media.caption && (
+                                    <p className="text-xs text-gray-600 mt-1">{media.caption}</p>
+                                  )}
+                                </div>
                             ))}
                         </div>
                       </TabsContent>
@@ -270,16 +273,18 @@ export default function JobPage({ params }: JobPageProps) {
                           {progressRecord.media
                             .filter(m => m.kind === 'AFTER')
                             .map((media) => (
-                              <div key={media.id} className="relative">
-                                <img
-                                  src={media.url}
-                                  alt={media.caption || "Sonra"}
-                                  className="w-full h-32 object-cover rounded-md"
-                                />
-                                {media.caption && (
-                                  <p className="text-xs text-gray-600 mt-1">{media.caption}</p>
-                                )}
-                              </div>
+                                <div key={media.id} className="relative">
+                                  <Image
+                                    src={media.url}
+                                    alt={media.caption || "Sonra"}
+                                    className="w-full h-32 object-cover rounded-md"
+                                    width={500}
+                                    height={500}
+                                  />
+                                  {media.caption && (
+                                    <p className="text-xs text-gray-600 mt-1">{media.caption}</p>
+                                  )}
+                                </div>
                             ))}
                         </div>
                       </TabsContent>

--- a/lib/trpc/server.ts
+++ b/lib/trpc/server.ts
@@ -21,47 +21,49 @@ const isAuthed = t.middleware(({ next, ctx }) => {
   });
 });
 
-const isAdmin = t.middleware(({ next, ctx }) => {
-  if (!ctx.session?.user) {
-    throw new TRPCError({
-      code: 'UNAUTHORIZED',
-      message: 'Not authenticated',
+  const isAdmin = t.middleware(({ next, ctx }) => {
+    if (!ctx.session?.user) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'Not authenticated',
+      });
+    }
+    const sessionUser = ctx.session.user as { role?: string };
+    if (sessionUser.role !== 'ADMIN') {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Admin access required',
+      });
+    }
+    return next({
+      ctx: {
+        ...ctx,
+        session: ctx.session,
+      },
     });
-  }
-  if (ctx.session.user.role !== 'ADMIN') {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message: 'Admin access required',
-    });
-  }
-  return next({
-    ctx: {
-      ...ctx,
-      session: ctx.session,
-    },
   });
-});
 
-const isCrewOrAdmin = t.middleware(({ next, ctx }) => {
-  if (!ctx.session?.user) {
-    throw new TRPCError({
-      code: 'UNAUTHORIZED',
-      message: 'Not authenticated',
+  const isCrewOrAdmin = t.middleware(({ next, ctx }) => {
+    if (!ctx.session?.user) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'Not authenticated',
+      });
+    }
+    const sessionUser = ctx.session.user as { role?: string };
+    if (!['ADMIN', 'CREW'].includes(sessionUser.role || '')) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Crew or admin access required',
+      });
+    }
+    return next({
+      ctx: {
+        ...ctx,
+        session: ctx.session,
+      },
     });
-  }
-  if (!['ADMIN', 'CREW'].includes(ctx.session.user.role)) {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message: 'Crew or admin access required',
-    });
-  }
-  return next({
-    ctx: {
-      ...ctx,
-      session: ctx.session,
-    },
   });
-});
 
 export const router = t.router;
 export const publicProcedure = t.procedure;


### PR DESCRIPTION
## Summary
- escape unencoded quotes in admin dashboard
- replace img tags with Next.js Image component
- cast session user in tRPC routers and middleware to avoid undefined access

## Testing
- `npm run lint`
- `npm run build` *(fails: Page "/api/trpc/[trpc]" is missing `generateStaticParams()` so it cannot be used with `output: export` config)*

------
https://chatgpt.com/codex/tasks/task_e_689d094a93388321a3580c7354f96054